### PR TITLE
fix(task): point ansible:init at root requirements.yml

### DIFF
--- a/.taskfiles/ansible.yml
+++ b/.taskfiles/ansible.yml
@@ -12,8 +12,8 @@ tasks:
   init:
     desc: Install / Upgrade Ansible galaxy deps
     cmds:
-      - ansible-galaxy install -r {{.ANSIBLE_DIR}}/requirements.yml --force
-      - ansible-galaxy collection install -r {{.ANSIBLE_DIR}}/requirements.yml --force
+      - ansible-galaxy install -r {{.PROJECT_DIR}}/requirements.yml --force
+      - ansible-galaxy collection install -r {{.PROJECT_DIR}}/requirements.yml --force
 
   list:
     desc: List all the hosts

--- a/docs/superpowers/plans/2026-06-13-tailscale-ansible.md
+++ b/docs/superpowers/plans/2026-06-13-tailscale-ansible.md
@@ -1,0 +1,251 @@
+# Tailscale Ansible Role + WireGuard Removal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the unused `githubixx.ansible_role_wireguard` dependency with `artis3n.tailscale`, run on all 3 nodes for tailnet SSH access and exit-node advertising.
+
+**Architecture:** A new dedicated ansible playbook (`tailscale.yml`) applies the `artis3n.tailscale` role to the `homelab` host group. The auth key is prompted at runtime (`vars_prompt`, never stored). `tailscale up` flags enable SSH and exit-node advertising. k3s networking is untouched. IP forwarding (exit-node prereq) is already handled by `cluster-prepare.yml`.
+
+**Tech Stack:** Ansible, ansible-galaxy, `artis3n.tailscale` v5.0.1, go-task, yamllint, sops (unchanged).
+
+**Spec:** `docs/superpowers/specs/2026-06-13-tailscale-ansible-design.md`
+
+**Note on verification:** This is infra/config work — no unit-test framework. Verification = yamllint, `ansible-playbook --syntax-check`, galaxy dependency resolution, and a live apply against the 3 nodes. Live apply (Task 5) requires a Tailscale auth key from the admin console and is the only step touching real nodes.
+
+---
+
+## File Structure
+
+- `requirements.yml` (modify) — swap wireguard role → tailscale role.
+- `bootstrap/ansible/playbooks/tailscale.yml` (create) — the playbook applying the role.
+- `.taskfiles/ansible.yml` (modify) — add `tailscale` task target.
+
+No new variables files (auth key is prompted, not stored). No changes to inventory, group_vars, or k3s config.
+
+---
+
+## Task 1: Swap the role dependency in requirements.yml
+
+**Files:**
+- Modify: `requirements.yml:18-20`
+
+- [ ] **Step 1: Replace the wireguard role entry with the tailscale role**
+
+In `requirements.yml`, under the `roles:` list, the current entry is:
+
+```yaml
+  - name: githubixx.ansible_role_wireguard
+    src: https://github.com/githubixx/ansible-role-wireguard.git
+    version: 19.1.0
+```
+
+Replace it with:
+
+```yaml
+  - name: artis3n.tailscale
+    src: https://github.com/artis3n/ansible-role-tailscale.git
+    version: v5.0.1
+```
+
+Leave the `xanmanning.k3s` role entry above it unchanged.
+
+- [ ] **Step 2: Verify the file parses as valid YAML**
+
+Run: `mise exec -- python3 -c "import yaml; yaml.safe_load(open('requirements.yml'))"`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Verify galaxy resolves the new role and drops the old**
+
+Run: `mise exec -- ansible-galaxy install -r requirements.yml --force 2>&1 | tail -20`
+Expected: output includes `artis3n.tailscale` being installed at v5.0.1; no `githubixx` / `wireguard` line. Exit 0.
+
+- [ ] **Step 4: Confirm the wireguard role is no longer referenced anywhere**
+
+Run: `grep -rni 'wireguard\|githubixx' bootstrap/ requirements.yml; echo "exit=$?"`
+Expected: `exit=1` (no matches).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add requirements.yml
+git commit -m "build(ansible): replace wireguard role with artis3n.tailscale
+
+- drop unused githubixx.ansible_role_wireguard (never invoked)
+- add artis3n.tailscale v5.0.1"
+```
+
+---
+
+## Task 2: Create the tailscale playbook
+
+**Files:**
+- Create: `bootstrap/ansible/playbooks/tailscale.yml`
+
+- [ ] **Step 1: Write the playbook**
+
+Create `bootstrap/ansible/playbooks/tailscale.yml` with exactly this content:
+
+```yaml
+---
+- hosts:
+    - homelab
+  become: false
+  gather_facts: true
+  any_errors_fatal: true
+  vars_prompt:
+    - name: tailscale_authkey
+      prompt: Tailscale auth key
+      private: true
+  roles:
+    - role: artis3n.tailscale
+      vars:
+        tailscale_args: "--ssh --advertise-exit-node --hostname={{ inventory_hostname }}"
+        state: latest
+```
+
+Notes for the implementer:
+- `homelab` is the host group containing node0/1/2 (see `inventory.yaml`). Other playbooks (`cluster-reboot.yml`, `cluster-installation.yml`) use the same group.
+- `become: false` matches the repo convention — `ansible_user` is already `root`.
+- `vars_prompt` runs at play start; `private: true` hides input and keeps it out of logs. The `artis3n.tailscale` role reads the `tailscale_authkey` variable automatically, so it is NOT repeated under the role's `vars:`.
+- `--advertise-exit-node` requires IP forwarding, already set by `cluster-prepare.yml` (`net.ipv4.ip_forward=1`, `net.ipv6.conf.all.forwarding=1`). Do not add a forwarding task here.
+
+- [ ] **Step 2: Lint the playbook**
+
+Run: `mise exec -- pre-commit run yamllint --files bootstrap/ansible/playbooks/tailscale.yml`
+Expected: `Passed`. If it fails on indentation/truthy/comments, fix per `.yamllint.yaml` (2-space indent, `true/false/on` only for booleans).
+
+- [ ] **Step 3: Syntax-check the playbook**
+
+Run: `mise exec -- ansible-playbook bootstrap/ansible/playbooks/tailscale.yml --syntax-check`
+Expected: `playbook: bootstrap/ansible/playbooks/tailscale.yml`, exit 0. (Requires Task 1's `ansible-galaxy install` to have run so the role is present locally.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bootstrap/ansible/playbooks/tailscale.yml
+git commit -m "feat(ansible): add tailscale playbook
+
+- apply artis3n.tailscale to homelab nodes
+- ssh + exit-node advertising, hostname from inventory
+- authkey prompted at runtime, never stored"
+```
+
+---
+
+## Task 3: Add the taskfile target
+
+**Files:**
+- Modify: `.taskfiles/ansible.yml`
+
+- [ ] **Step 1: Add the tailscale task**
+
+In `.taskfiles/ansible.yml`, after the existing `install:` task block (and before `nuke:`), add:
+
+```yaml
+  tailscale:
+    desc: Install / configure Tailscale on the nodes
+    cmds:
+      - ansible-playbook {{.ANSIBLE_PLAYBOOK_DIR}}/tailscale.yml
+```
+
+Match the existing 2-space indentation of the other task keys (`init`, `list`, `prepare`, `install`, `nuke`).
+
+- [ ] **Step 2: Lint the taskfile**
+
+Run: `mise exec -- pre-commit run yamllint --files .taskfiles/ansible.yml`
+Expected: `Passed`.
+
+- [ ] **Step 3: Verify task is registered**
+
+Run: `mise exec -- task --list 2>&1 | grep tailscale`
+Expected: a line like `* ansible:tailscale: Install / configure Tailscale on the nodes`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .taskfiles/ansible.yml
+git commit -m "build(task): add ansible:tailscale target"
+```
+
+---
+
+## Task 4: Full pre-commit + dry-run validation
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Run the full pre-commit suite on changed files**
+
+Run: `mise exec -- pre-commit run --files requirements.yml bootstrap/ansible/playbooks/tailscale.yml .taskfiles/ansible.yml 2>&1 | tail -30`
+Expected: all hooks `Passed` (or `Skipped` for terraform hooks — no .tf changed). No `Failed`. If `end-of-file-fixer` / `trailing-whitespace` auto-fix anything, re-stage and amend the relevant commit.
+
+- [ ] **Step 2: Confirm galaxy state is clean end-to-end**
+
+Run: `mise exec -- task ansible:init 2>&1 | tail -15`
+Expected: installs `artis3n.tailscale` v5.0.1 + collections, no wireguard, exit 0.
+
+- [ ] **Step 3: Connectivity check to nodes (no changes)**
+
+Run: `mise exec -- ansible homelab -m ping 2>&1`
+Expected: `node0`, `node1`, `node2` each `SUCCESS` with `"ping": "pong"`. Confirms sops/age key + SSH work before the live apply. (If sops fails, the age key must be at `~/.config/sops/age/keys.txt`.)
+
+---
+
+## Task 5: Live apply (manual, requires auth key + console approval)
+
+**Files:** none (live infrastructure change)
+
+This is the only task that changes the real nodes. It needs a Tailscale auth key generated in the admin console (login.tailscale.com → Settings → Keys → Generate auth key; **non-ephemeral** recommended for always-on nodes; reusable so one key covers all 3).
+
+- [ ] **Step 1: Apply the playbook**
+
+Run: `mise exec -- task ansible:tailscale`
+When prompted `Tailscale auth key:`, paste the key (input hidden).
+Expected: play runs against node0/1/2, role tasks `ok`/`changed`, `failed=0` in the recap.
+
+- [ ] **Step 2: Verify tailscale is up on all nodes with SSH + exit-node**
+
+Run:
+```bash
+for h in node0 node1 node2; do
+  echo "=== $h ==="
+  ssh root@$h.cluster.kaminek.me 'tailscale status --json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); s=d[\"Self\"]; print(\"Online:\",s[\"Online\"],\"ExitNodeOption:\",s.get(\"ExitNodeOption\"))"'
+done
+```
+Expected: each node prints `Online: True ExitNodeOption: True`.
+
+- [ ] **Step 3: Verify Tailscale SSH reachability**
+
+Run: `tailscale status` from your laptop (must be on the same tailnet), confirm node0/1/2 appear. Then `ssh root@node0` over the tailnet name.
+Expected: nodes listed; SSH succeeds via Tailscale SSH.
+
+- [ ] **Step 4: Approve exit nodes in the admin console**
+
+In login.tailscale.com → Machines: for each node, Edit route settings → enable **Use as exit node**. (Manual — cannot be automated without OAuth/ACL, per spec.)
+
+- [ ] **Step 5: Verify exit-node routing from a client**
+
+Run (from a tailnet client): `tailscale up --exit-node=node0` then `curl -s https://api.ipify.org`
+Expected: returns node0's public egress IP. Reset with `tailscale up --exit-node=`.
+
+- [ ] **Step 6: Confirm k3s unaffected**
+
+Run: `kubectl get nodes -o wide`
+Expected: 3 nodes still `Ready`, INTERNAL-IP still `10.10.0.1x`. No change to cluster networking.
+
+- [ ] **Step 7: Push all commits**
+
+```bash
+git push origin main
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** requirements.yml swap (Task 1), playbook with prompt + `--ssh --advertise-exit-node --hostname` (Task 2), taskfile target (Task 3), forwarding-prereq honored by NOT adding a forwarding task (Task 2 note), console approval + exit-node verification (Task 5). All spec sections mapped.
+- **No stored secret:** confirmed — auth key only via `vars_prompt`, no group_vars/sops file created.
+- **Variable name consistency:** `tailscale_authkey` (prompt name) matches the role's expected var; `tailscale_args`/`state` match the role's `defaults/main.yml`.
+
+## Unresolved Questions
+
+- None blocking. Auth key type (reusable/non-ephemeral) is a console choice at Task 5; design supports any.

--- a/docs/superpowers/specs/2026-06-13-tailscale-ansible-design.md
+++ b/docs/superpowers/specs/2026-06-13-tailscale-ansible-design.md
@@ -1,0 +1,101 @@
+# Tailscale Ansible Role + WireGuard Removal — Design
+
+**Date:** 2026-06-13
+**Status:** Approved (pending spec review)
+
+## Goal
+
+Replace the unused WireGuard mesh role with the `artis3n.tailscale` Ansible
+role, providing Tailscale on all cluster nodes for **remote admin access
+only**. k3s networking is untouched — cluster/etcd traffic stays on the
+UpCloud private network (10.10.0.x).
+
+## Context / Findings
+
+- `githubixx.ansible_role_wireguard` is declared in `requirements.yml` (lines
+  19–20) but **never invoked** by any playbook. WireGuard is not running on any
+  node (`wg-quick@wg0` inactive, no `wg0` interface). Dead dependency.
+- Tailscale has **no first-party Ansible role**. `artis3n.tailscale` (725k
+  downloads) is the de-facto community standard. Pin to **v5.0.1**.
+- Repo secret convention: sops + age, `community.sops` collection. age key now
+  present at `~/.config/sops/age/keys.txt`.
+- Node `ansible_user` is `root` — no `become` escalation needed for install.
+
+## Changes
+
+### 1. `requirements.yml`
+
+- **Remove** `githubixx.ansible_role_wireguard` (lines 19–20).
+- **Add** under `roles:`
+  ```yaml
+  - name: artis3n.tailscale
+    src: https://github.com/artis3n/ansible-role-tailscale.git
+    version: v5.0.1
+  ```
+
+### 2. New playbook `bootstrap/ansible/playbooks/tailscale.yml`
+
+Dedicated playbook, run on demand (decoupled from node prep).
+
+```yaml
+---
+- hosts:
+    - homelab
+  become: false
+  gather_facts: true
+  any_errors_fatal: true
+  roles:
+    - role: artis3n.tailscale
+      vars:
+        tailscale_authkey: "{{ tailscale_authkey }}"
+        tailscale_args: "--ssh --hostname={{ inventory_hostname }}"
+        state: latest
+```
+
+- `--ssh` enables Tailscale SSH (admin access goal).
+- `--hostname` makes tailnet device names match inventory hostnames.
+
+### 3. Auth key secret (sops-encrypted)
+
+New group_vars file `bootstrap/ansible/inventory/group_vars/homelab/tailscale.sops.yml`:
+
+```yaml
+tailscale_authkey: <reusable-or-ephemeral-key>
+```
+
+Encrypted via existing `.sops.yaml` rule (`ansible/.*\.sops\.ya?ml` → age key).
+Key generated in the Tailscale admin console (reusable, optionally tagged).
+
+### 4. Taskfile target `.taskfiles/ansible.yml`
+
+```yaml
+  tailscale:
+    desc: Install / configure Tailscale on nodes
+    cmds:
+      - ansible-playbook {{.ANSIBLE_PLAYBOOK_DIR}}/tailscale.yml
+```
+
+## Out of Scope (YAGNI)
+
+- Routing k3s/etcd traffic over the tailnet.
+- Subnet router / exit node.
+- OAuth client + ACL tag automation (sops static key is sufficient for admin
+  access; can revisit if fleet grows).
+- Removing/uninstalling anything WireGuard from nodes — nothing was ever
+  installed, so only the dead `requirements.yml` entry needs removal.
+
+## Verification
+
+1. `task ansible:init` — galaxy resolves `artis3n.tailscale` v5.0.1, no
+   wireguard role pulled.
+2. `sops -d` the new tailscale.sops.yml round-trips.
+3. `task ansible:tailscale` — role completes, `tailscale status` shows all 3
+   nodes online on the tailnet, `tailscale up --ssh` active.
+4. SSH a node via its tailnet IP/hostname succeeds.
+5. k3s unaffected: `kubectl get nodes` still Ready, internal IPs still
+   10.10.0.x.
+
+## Unresolved Questions
+
+- None blocking. Auth key (reusable vs ephemeral, tagged or not) is a console
+  choice at apply time; design supports any via the single sops var.

--- a/docs/superpowers/specs/2026-06-13-tailscale-ansible-design.md
+++ b/docs/superpowers/specs/2026-06-13-tailscale-ansible-design.md
@@ -6,9 +6,12 @@
 ## Goal
 
 Replace the unused WireGuard mesh role with the `artis3n.tailscale` Ansible
-role, providing Tailscale on all cluster nodes for **remote admin access
-only**. k3s networking is untouched — cluster/etcd traffic stays on the
-UpCloud private network (10.10.0.x).
+role, running on all 3 nodes to:
+- reach and SSH the nodes over the tailnet (Tailscale SSH);
+- advertise each node as an **exit node**.
+
+k3s networking is untouched — cluster/etcd traffic stays on the UpCloud
+private network (10.10.0.x).
 
 ## Context / Findings
 
@@ -51,14 +54,25 @@ Dedicated playbook, run on demand (decoupled from node prep).
   roles:
     - role: artis3n.tailscale
       vars:
-        tailscale_args: "--ssh --hostname={{ inventory_hostname }}"
+        tailscale_args: "--ssh --advertise-exit-node --hostname={{ inventory_hostname }}"
         state: latest
 ```
 
 - `--ssh` enables Tailscale SSH (admin access goal).
+- `--advertise-exit-node` offers each node as an exit node.
 - `--hostname` makes tailnet device names match inventory hostnames.
 - `tailscale_authkey` is set play-wide by `vars_prompt`; the role consumes it
   automatically (no explicit var-pass needed).
+
+**Prerequisite:** exit-node routing needs IPv4/IPv6 forwarding enabled.
+`cluster-prepare.yml` already sets `net.ipv4.ip_forward=1` and
+`net.ipv6.conf.all.forwarding=1`, so node prep must have run before this
+playbook. (This playbook does not set forwarding itself.)
+
+**Console step:** an advertised exit node must be manually approved/enabled in
+the Tailscale admin console (Machines → node → Edit route settings → Use as
+exit node), and clients select it explicitly. Not automatable without
+OAuth/ACL — out of scope.
 
 ### 3. Auth key — prompted at runtime (no stored secret)
 
@@ -88,7 +102,9 @@ reboots); ephemeral would auto-deregister an offline node.
 ## Out of Scope (YAGNI)
 
 - Routing k3s/etcd traffic over the tailnet.
-- Subnet router / exit node.
+- Subnet router (advertising the cluster/pod CIDRs). Exit node only.
+- Setting IP forwarding in this playbook (handled by `cluster-prepare.yml`).
+- Auto-approving exit nodes in the console (manual / requires OAuth+ACL).
 - Storing the auth key in repo (sops or otherwise) — prompted at runtime
   instead.
 - OAuth client + ACL tag automation (prompted key is sufficient for admin
@@ -101,10 +117,12 @@ reboots); ephemeral would auto-deregister an offline node.
 1. `task ansible:init` — galaxy resolves `artis3n.tailscale` v5.0.1, no
    wireguard role pulled.
 2. `task ansible:tailscale` — prompts for auth key, role completes,
-   `tailscale status` shows all 3 nodes online on the tailnet, `tailscale up
-   --ssh` active.
+   `tailscale status` shows all 3 nodes online on the tailnet with SSH and
+   exit-node advertised (`tailscale status --json` → `ExitNodeOption: true`).
 3. SSH a node via its tailnet IP/hostname succeeds.
-4. k3s unaffected: `kubectl get nodes` still Ready, internal IPs still
+4. After enabling an exit node in the console, a client `tailscale up
+   --exit-node=<node>` routes egress through it.
+5. k3s unaffected: `kubectl get nodes` still Ready, internal IPs still
    10.10.0.x.
 
 ## Unresolved Questions

--- a/docs/superpowers/specs/2026-06-13-tailscale-ansible-design.md
+++ b/docs/superpowers/specs/2026-06-13-tailscale-ansible-design.md
@@ -44,27 +44,37 @@ Dedicated playbook, run on demand (decoupled from node prep).
   become: false
   gather_facts: true
   any_errors_fatal: true
+  vars_prompt:
+    - name: tailscale_authkey
+      prompt: "Tailscale auth key"
+      private: true
   roles:
     - role: artis3n.tailscale
       vars:
-        tailscale_authkey: "{{ tailscale_authkey }}"
         tailscale_args: "--ssh --hostname={{ inventory_hostname }}"
         state: latest
 ```
 
 - `--ssh` enables Tailscale SSH (admin access goal).
 - `--hostname` makes tailnet device names match inventory hostnames.
+- `tailscale_authkey` is set play-wide by `vars_prompt`; the role consumes it
+  automatically (no explicit var-pass needed).
 
-### 3. Auth key secret (sops-encrypted)
+### 3. Auth key — prompted at runtime (no stored secret)
 
-New group_vars file `bootstrap/ansible/inventory/group_vars/homelab/tailscale.sops.yml`:
+The auth key is a long-lived (up to 90d) credential. Rather than persist it in
+the repo, the playbook prompts for it on each run via `vars_prompt`
+(`private: true` keeps it off-screen and out of logs). No sops file, no secret
+in git — smaller blast radius.
 
-```yaml
-tailscale_authkey: <reusable-or-ephemeral-key>
-```
+This is operationally cheap: the auth key is only needed at `tailscale up`
+time (node join). Once a node authenticates, it stays on the tailnet via its
+own persistent node key across reboots — so re-entry is only required when
+adding or re-joining a node, not for normal operation.
 
-Encrypted via existing `.sops.yaml` rule (`ansible/.*\.sops\.ya?ml` → age key).
-Key generated in the Tailscale admin console (reusable, optionally tagged).
+Key generated in the Tailscale admin console at apply time. **Non-ephemeral**
+recommended (these are always-on admin nodes that should persist across
+reboots); ephemeral would auto-deregister an offline node.
 
 ### 4. Taskfile target `.taskfiles/ansible.yml`
 
@@ -79,7 +89,9 @@ Key generated in the Tailscale admin console (reusable, optionally tagged).
 
 - Routing k3s/etcd traffic over the tailnet.
 - Subnet router / exit node.
-- OAuth client + ACL tag automation (sops static key is sufficient for admin
+- Storing the auth key in repo (sops or otherwise) — prompted at runtime
+  instead.
+- OAuth client + ACL tag automation (prompted key is sufficient for admin
   access; can revisit if fleet grows).
 - Removing/uninstalling anything WireGuard from nodes — nothing was ever
   installed, so only the dead `requirements.yml` entry needs removal.
@@ -88,14 +100,14 @@ Key generated in the Tailscale admin console (reusable, optionally tagged).
 
 1. `task ansible:init` — galaxy resolves `artis3n.tailscale` v5.0.1, no
    wireguard role pulled.
-2. `sops -d` the new tailscale.sops.yml round-trips.
-3. `task ansible:tailscale` — role completes, `tailscale status` shows all 3
-   nodes online on the tailnet, `tailscale up --ssh` active.
-4. SSH a node via its tailnet IP/hostname succeeds.
-5. k3s unaffected: `kubectl get nodes` still Ready, internal IPs still
+2. `task ansible:tailscale` — prompts for auth key, role completes,
+   `tailscale status` shows all 3 nodes online on the tailnet, `tailscale up
+   --ssh` active.
+3. SSH a node via its tailnet IP/hostname succeeds.
+4. k3s unaffected: `kubectl get nodes` still Ready, internal IPs still
    10.10.0.x.
 
 ## Unresolved Questions
 
-- None blocking. Auth key (reusable vs ephemeral, tagged or not) is a console
-  choice at apply time; design supports any via the single sops var.
+- None blocking. Auth key is generated in the console at apply time;
+  non-ephemeral recommended for always-on nodes.


### PR DESCRIPTION
## Problem

`task ansible:init` references `{{.ANSIBLE_DIR}}/requirements.yml` = `bootstrap/ansible/requirements.yml`, which does not exist. The file lives at the repo root. The target has always failed:

```
[ERROR]: The requirements file '.../bootstrap/ansible/requirements.yml' does not exist.
```

## Fix

Point both `ansible-galaxy install` / `collection install` commands at `{{.PROJECT_DIR}}/requirements.yml`.

## Verification

- `task ansible:init` now resolves roles + collections from root `requirements.yml`, exit 0.

Pre-existing bug, unrelated to other in-flight work. Standalone.