### PR TITLE
fix(ansible): allow packet forwarding via os_hardening override

### DIFF
--- a/bootstrap/ansible/inventory/group_vars/homelab/os.yml
+++ b/bootstrap/ansible/inventory/group_vars/homelab/os.yml
@@ -14,6 +14,11 @@ os_selinux_policy: targeted
 ufw_manage_defaults: false
 os_rhosts_enabled: false
 hidepid_option: 0
+# allow packet forwarding (k3s/cilium + tailscale exit nodes need it);
+# os_hardening defaults both to 0, which overrides /etc/sysctl.d on boot
+sysctl_overwrite:
+  net.ipv4.ip_forward: 1
+  net.ipv6.conf.all.forwarding: 1
 # ssh hardening
 network_ipv6_enable: false
 ssh_permit_root_login: "yes"


### PR DESCRIPTION
## Problem

`devsec.hardening.os_hardening` (run by `cluster-prepare.yml`) writes its sysctl defaults to `/etc/sysctl.conf`, including:

```
net.ipv4.ip_forward = 0
net.ipv6.conf.all.forwarding = 0
```

`/etc/sysctl.conf` is applied **after** `/etc/sysctl.d/*` on boot, so it overrides the cluster's own `99-kubernetes.conf` (which sets these to 1). Net effect on all 3 nodes: **`net.ipv6.conf.all.forwarding=0`** at runtime. IPv4 ends up 1 only because k3s/cilium force it; IPv6 has nothing re-enabling it.

This breaks IPv6 packet forwarding — needed by k3s/cilium and by Tailscale exit nodes (`tailscale status` reports `IP forwarding is disabled`).

## Fix

Set `sysctl_overwrite` in `group_vars/homelab/os.yml` so os_hardening writes `1` for both forwarding keys:

```yaml
sysctl_overwrite:
  net.ipv4.ip_forward: 1
  net.ipv6.conf.all.forwarding: 1
```

Durable: survives reboots and re-runs of `cluster-prepare`, fixing at the source rather than editing `/etc/sysctl.conf` by hand (which os_hardening would just rewrite).

## Verification

- Applied live + confirmed: `net.ipv4.ip_forward=1`, `net.ipv6.conf.all.forwarding=1` on node0/1/2.
- `tailscale status` health warning cleared.

> Stacked on #324 (init fix). Independent cluster-hardening fix — applies regardless of the tailscale work.