### PR TITLE
feat(ansible): add tailscale via artis3n collection (oauth, ssh + exit nodes)

### DIFF
--- a/.taskfiles/ansible.yml
+++ b/.taskfiles/ansible.yml
@@ -30,6 +30,11 @@ tasks:
     cmds:
       - ansible-playbook {{.ANSIBLE_PLAYBOOK_DIR}}/cluster-installation.yml
 
+  tailscale:
+    desc: Install / configure Tailscale on the nodes
+    cmds:
+      - ansible-playbook {{.ANSIBLE_PLAYBOOK_DIR}}/tailscale.yml
+
   nuke:
     desc: Nuke the cluster
     cmds:

--- a/bootstrap/ansible/playbooks/tailscale.yml
+++ b/bootstrap/ansible/playbooks/tailscale.yml
@@ -1,0 +1,19 @@
+---
+- hosts:
+    - homelab
+  become: false
+  gather_facts: true
+  any_errors_fatal: true
+  vars_prompt:
+    - name: tailscale_authkey
+      prompt: Tailscale OAuth client secret (tskey-client-...)
+      private: true
+  roles:
+    - role: artis3n.tailscale.machine
+      vars:
+        tailscale_args: "--ssh --advertise-exit-node --hostname={{ inventory_hostname }}"
+        tailscale_tags:
+          - homelab
+        tailscale_oauth_ephemeral: false
+        tailscale_oauth_preauthorized: true
+        state: latest

--- a/docs/superpowers/plans/2026-06-13-tailscale-ansible.md
+++ b/docs/superpowers/plans/2026-06-13-tailscale-ansible.md
@@ -4,13 +4,15 @@
 
 **Goal:** Replace the unused `githubixx.ansible_role_wireguard` dependency with `artis3n.tailscale`, run on all 3 nodes for tailnet SSH access and exit-node advertising.
 
-**Architecture:** A new dedicated ansible playbook (`tailscale.yml`) applies the `artis3n.tailscale` role to the `homelab` host group. The auth key is prompted at runtime (`vars_prompt`, never stored). `tailscale up` flags enable SSH and exit-node advertising. k3s networking is untouched. IP forwarding (exit-node prereq) is already handled by `cluster-prepare.yml`.
+**Architecture:** A new dedicated ansible playbook (`tailscale.yml`) applies the `artis3n.tailscale.machine` role (from the `artis3n.tailscale` collection) to the `homelab` host group. Authentication uses a Tailscale OAuth client secret prompted at runtime (`vars_prompt`, never stored); nodes are tagged `tag:homelab`. `tailscale up` flags enable SSH and exit-node advertising. k3s networking is untouched. IP forwarding (exit-node prereq) is already handled by `cluster-prepare.yml`.
 
-**Tech Stack:** Ansible, ansible-galaxy, `artis3n.tailscale` v5.0.1, go-task, yamllint, sops (unchanged).
+> **Update (post-implementation):** the standalone role `artis3n.tailscale` v5.0.1 was found to break on ansible-core 2.21 (strict boolean conditionals reject its `meta: end_role` migration-notice task; `INJECT_FACTS_AS_VARS` deprecation). Migrated to the successor **collection `artis3n.tailscale` v1.2.1**, role `artis3n.tailscale.machine` — same variable interface, both issues fixed. The requirements/playbook snippets below reflect the final collection-based state.
+
+**Tech Stack:** Ansible, ansible-galaxy, `artis3n.tailscale` collection v1.2.1 (role `.machine`), go-task, yamllint, sops (unchanged).
 
 **Spec:** `docs/superpowers/specs/2026-06-13-tailscale-ansible-design.md`
 
-**Note on verification:** This is infra/config work — no unit-test framework. Verification = yamllint, `ansible-playbook --syntax-check`, galaxy dependency resolution, and a live apply against the 3 nodes. Live apply (Task 5) requires a Tailscale auth key from the admin console and is the only step touching real nodes.
+**Note on verification:** This is infra/config work — no unit-test framework. Verification = yamllint, `ansible-playbook --syntax-check`, galaxy dependency resolution, and a live apply against the 3 nodes. Live apply (Task 5) requires a Tailscale OAuth client secret (plus a one-time `tag:homelab` ACL/OAuth setup) and is the only step touching real nodes.
 
 ---
 
@@ -20,7 +22,7 @@
 - `bootstrap/ansible/playbooks/tailscale.yml` (create) — the playbook applying the role.
 - `.taskfiles/ansible.yml` (modify) — add `tailscale` task target.
 
-No new variables files (auth key is prompted, not stored). No changes to inventory, group_vars, or k3s config.
+No new variables files (OAuth client secret is prompted, not stored). No changes to inventory, group_vars, or k3s config.
 
 ---
 
@@ -39,15 +41,14 @@ In `requirements.yml`, under the `roles:` list, the current entry is:
     version: 19.1.0
 ```
 
-Replace it with:
+Remove it. Add the tailscale **collection** under the `collections:` list instead (final state after the v5 → collection migration):
 
 ```yaml
   - name: artis3n.tailscale
-    src: https://github.com/artis3n/ansible-role-tailscale.git
-    version: v5.0.1
+    version: 1.2.1
 ```
 
-Leave the `xanmanning.k3s` role entry above it unchanged.
+Leave the `xanmanning.k3s` role entry unchanged.
 
 - [ ] **Step 2: Verify the file parses as valid YAML**
 
@@ -56,8 +57,8 @@ Expected: no output, exit 0.
 
 - [ ] **Step 3: Verify galaxy resolves the new role and drops the old**
 
-Run: `mise exec -- ansible-galaxy install -r requirements.yml --force 2>&1 | tail -20`
-Expected: output includes `artis3n.tailscale` being installed at v5.0.1; no `githubixx` / `wireguard` line. Exit 0.
+Run: `mise exec -- ansible-galaxy collection install -r requirements.yml --force 2>&1 | tail -20`
+Expected: output includes `artis3n.tailscale:1.2.1 was installed successfully`; no `githubixx` / `wireguard` line. Exit 0.
 
 - [ ] **Step 4: Confirm the wireguard role is no longer referenced anywhere**
 
@@ -94,19 +95,27 @@ Create `bootstrap/ansible/playbooks/tailscale.yml` with exactly this content:
   any_errors_fatal: true
   vars_prompt:
     - name: tailscale_authkey
-      prompt: Tailscale auth key
+      prompt: Tailscale OAuth client secret (tskey-client-...)
       private: true
   roles:
-    - role: artis3n.tailscale
+    - role: artis3n.tailscale.machine
       vars:
         tailscale_args: "--ssh --advertise-exit-node --hostname={{ inventory_hostname }}"
+        tailscale_tags:
+          - homelab
+        tailscale_oauth_ephemeral: false
+        tailscale_oauth_preauthorized: true
         state: latest
 ```
 
 Notes for the implementer:
 - `homelab` is the host group containing node0/1/2 (see `inventory.yaml`). Other playbooks (`cluster-reboot.yml`, `cluster-installation.yml`) use the same group.
 - `become: false` matches the repo convention — `ansible_user` is already `root`.
-- `vars_prompt` runs at play start; `private: true` hides input and keeps it out of logs. The `artis3n.tailscale` role reads the `tailscale_authkey` variable automatically, so it is NOT repeated under the role's `vars:`.
+- `vars_prompt` runs at play start; `private: true` hides input and keeps it out of logs. The `artis3n.tailscale.machine` role reads the `tailscale_authkey` variable automatically, so it is NOT repeated under the role's `vars:`.
+- Authentication is via a **Tailscale OAuth client secret** (`tskey-client-...`). The role auto-detects the `tskey-client-` prefix and exchanges it for an ephemeral key at `tailscale up` time.
+- `tailscale_tags: [homelab]` is **required** with OAuth — the role fails fast if an OAuth secret is supplied without tags. It becomes `--advertise-tags=tag:homelab`. `tag:homelab` must exist in the tailnet ACL `tagOwners`, and the OAuth client must be scoped to it.
+- `tailscale_oauth_ephemeral: false` — nodes are always-on and must persist (not auto-deregister when briefly offline).
+- `tailscale_oauth_preauthorized: true` — nodes join without a manual device-approval click.
 - `--advertise-exit-node` requires IP forwarding, already set by `cluster-prepare.yml` (`net.ipv4.ip_forward=1`, `net.ipv6.conf.all.forwarding=1`). Do not add a forwarding task here.
 
 - [ ] **Step 2: Lint the playbook**
@@ -125,7 +134,7 @@ Expected: `playbook: bootstrap/ansible/playbooks/tailscale.yml`, exit 0. (Requir
 git add bootstrap/ansible/playbooks/tailscale.yml
 git commit -m "feat(ansible): add tailscale playbook
 
-- apply artis3n.tailscale to homelab nodes
+- apply artis3n.tailscale.machine to homelab nodes
 - ssh + exit-node advertising, hostname from inventory
 - authkey prompted at runtime, never stored"
 ```
@@ -181,7 +190,7 @@ Expected: all hooks `Passed` (or `Skipped` for terraform hooks — no .tf change
 - [ ] **Step 2: Confirm galaxy state is clean end-to-end**
 
 Run: `mise exec -- task ansible:init 2>&1 | tail -15`
-Expected: installs `artis3n.tailscale` v5.0.1 + collections, no wireguard, exit 0.
+Expected: installs the `artis3n.tailscale` collection v1.2.1 + other collections, no wireguard, exit 0.
 
 - [ ] **Step 3: Connectivity check to nodes (no changes)**
 
@@ -190,37 +199,56 @@ Expected: `node0`, `node1`, `node2` each `SUCCESS` with `"ping": "pong"`. Confir
 
 ---
 
-## Task 5: Live apply (manual, requires auth key + console approval)
+## Task 5: Live apply (manual, requires OAuth client + tailnet ACL setup)
 
 **Files:** none (live infrastructure change)
 
-This is the only task that changes the real nodes. It needs a Tailscale auth key generated in the admin console (login.tailscale.com → Settings → Keys → Generate auth key; **non-ephemeral** recommended for always-on nodes; reusable so one key covers all 3).
+This is the only task that changes the real nodes. It uses a Tailscale OAuth
+client (not a static auth key).
+
+- [ ] **Step 0: One-time tailnet ACL + OAuth setup (console)**
+
+In login.tailscale.com:
+1. ACL policy → add `tag:homelab` to `tagOwners` (owner = your user/group):
+   ```json
+   "tagOwners": { "tag:homelab": ["autogroup:admin"] }
+   ```
+2. (Optional, to skip per-node exit-node approval) add an autoApprover:
+   ```json
+   "autoApprovers": { "exitNode": ["tag:homelab"] }
+   ```
+3. Trust credentials → Generate OAuth client. Scope: **Keys / `auth_keys` →
+   Write** (the minimal scope — not `devices:core`), tag `tag:homelab`. Copy
+   the client secret (`tskey-client-...`).
 
 - [ ] **Step 1: Apply the playbook**
 
 Run: `mise exec -- task ansible:tailscale`
-When prompted `Tailscale auth key:`, paste the key (input hidden).
+When prompted `Tailscale OAuth client secret (tskey-client-...):`, paste the
+secret (input hidden).
 Expected: play runs against node0/1/2, role tasks `ok`/`changed`, `failed=0` in the recap.
 
-- [ ] **Step 2: Verify tailscale is up on all nodes with SSH + exit-node**
+- [ ] **Step 2: Verify tailscale is up on all nodes with SSH + exit-node + tag**
 
 Run:
 ```bash
 for h in node0 node1 node2; do
   echo "=== $h ==="
-  ssh root@$h.cluster.kaminek.me 'tailscale status --json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); s=d[\"Self\"]; print(\"Online:\",s[\"Online\"],\"ExitNodeOption:\",s.get(\"ExitNodeOption\"))"'
+  ssh root@$h.cluster.kaminek.me 'tailscale status --json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); s=d[\"Self\"]; print(\"Online:\",s[\"Online\"],\"ExitNodeOption:\",s.get(\"ExitNodeOption\"),\"Tags:\",s.get(\"Tags\"))"'
 done
 ```
-Expected: each node prints `Online: True ExitNodeOption: True`.
+Expected: each node prints `Online: True ExitNodeOption: True Tags: ['tag:homelab']`.
 
 - [ ] **Step 3: Verify Tailscale SSH reachability**
 
 Run: `tailscale status` from your laptop (must be on the same tailnet), confirm node0/1/2 appear. Then `ssh root@node0` over the tailnet name.
 Expected: nodes listed; SSH succeeds via Tailscale SSH.
 
-- [ ] **Step 4: Approve exit nodes in the admin console**
+- [ ] **Step 4: Confirm exit nodes are approved**
 
-In login.tailscale.com → Machines: for each node, Edit route settings → enable **Use as exit node**. (Manual — cannot be automated without OAuth/ACL, per spec.)
+If the `autoApprovers.exitNode` entry from Step 0 was added, the nodes are
+already approved — confirm in login.tailscale.com → Machines (exit-node badge).
+Otherwise, for each node: Edit route settings → enable **Use as exit node**.
 
 - [ ] **Step 5: Verify exit-node routing from a client**
 
@@ -232,20 +260,17 @@ Expected: returns node0's public egress IP. Reset with `tailscale up --exit-node
 Run: `kubectl get nodes -o wide`
 Expected: 3 nodes still `Ready`, INTERNAL-IP still `10.10.0.1x`. No change to cluster networking.
 
-- [ ] **Step 7: Push all commits**
-
-```bash
-git push origin main
-```
+> Branch already pushed and PR #323 opened during Tasks 1–4. After the live
+> apply verifies, merge the PR.
 
 ---
 
 ## Self-Review Notes
 
 - **Spec coverage:** requirements.yml swap (Task 1), playbook with prompt + `--ssh --advertise-exit-node --hostname` (Task 2), taskfile target (Task 3), forwarding-prereq honored by NOT adding a forwarding task (Task 2 note), console approval + exit-node verification (Task 5). All spec sections mapped.
-- **No stored secret:** confirmed — auth key only via `vars_prompt`, no group_vars/sops file created.
-- **Variable name consistency:** `tailscale_authkey` (prompt name) matches the role's expected var; `tailscale_args`/`state` match the role's `defaults/main.yml`.
+- **No stored secret:** confirmed — OAuth client secret only via `vars_prompt`, no group_vars/sops file created.
+- **Variable name consistency:** `tailscale_authkey` (prompt name) matches the role's expected var (it accepts both static auth keys and OAuth client secrets, detected by prefix); `tailscale_tags`/`tailscale_oauth_ephemeral`/`tailscale_oauth_preauthorized`/`tailscale_args`/`state` match the role's `defaults/main.yml`.
 
 ## Unresolved Questions
 
-- None blocking. Auth key type (reusable/non-ephemeral) is a console choice at Task 5; design supports any.
+- None blocking. The OAuth client and `tag:homelab` ACL `tagOwners` are a one-time console/ACL setup at Task 5 Step 0.

--- a/docs/superpowers/specs/2026-06-13-tailscale-ansible-design.md
+++ b/docs/superpowers/specs/2026-06-13-tailscale-ansible-design.md
@@ -5,8 +5,9 @@
 
 ## Goal
 
-Replace the unused WireGuard mesh role with the `artis3n.tailscale` Ansible
-role, running on all 3 nodes to:
+Replace the unused WireGuard mesh role with the `artis3n.tailscale.machine`
+Ansible role (from the `artis3n.tailscale` collection), running on all 3 nodes
+to:
 - reach and SSH the nodes over the tailnet (Tailscale SSH);
 - advertise each node as an **exit node**.
 
@@ -18,8 +19,14 @@ private network (10.10.0.x).
 - `githubixx.ansible_role_wireguard` is declared in `requirements.yml` (lines
   19–20) but **never invoked** by any playbook. WireGuard is not running on any
   node (`wg-quick@wg0` inactive, no `wg0` interface). Dead dependency.
-- Tailscale has **no first-party Ansible role**. `artis3n.tailscale` (725k
-  downloads) is the de-facto community standard. Pin to **v5.0.1**.
+- Tailscale has **no first-party Ansible role**. The `artis3n` project is the
+  de-facto community standard. The standalone role (`artis3n.tailscale`
+  v5.0.1) is abandoned and **breaks on ansible-core ≥ 2.19** (a `meta:
+  end_role` task with a string `when:` violates strict boolean conditionals;
+  it also relies on the deprecated `INJECT_FACTS_AS_VARS`). Use the successor
+  **collection `artis3n.tailscale` v1.2.1**, role `artis3n.tailscale.machine`,
+  which fixes both (no migration-notice task, uses `ansible_facts.*`). Same
+  variable interface — drop-in.
 - Repo secret convention: sops + age, `community.sops` collection. age key now
   present at `~/.config/sops/age/keys.txt`.
 - Node `ansible_user` is `root` — no `become` escalation needed for install.
@@ -28,12 +35,11 @@ private network (10.10.0.x).
 
 ### 1. `requirements.yml`
 
-- **Remove** `githubixx.ansible_role_wireguard` (lines 19–20).
-- **Add** under `roles:`
+- **Remove** `githubixx.ansible_role_wireguard`.
+- **Add** under `collections:` (it is a collection, not a standalone role):
   ```yaml
   - name: artis3n.tailscale
-    src: https://github.com/artis3n/ansible-role-tailscale.git
-    version: v5.0.1
+    version: 1.2.1
   ```
 
 ### 2. New playbook `bootstrap/ansible/playbooks/tailscale.yml`
@@ -49,46 +55,62 @@ Dedicated playbook, run on demand (decoupled from node prep).
   any_errors_fatal: true
   vars_prompt:
     - name: tailscale_authkey
-      prompt: "Tailscale auth key"
+      prompt: Tailscale OAuth client secret (tskey-client-...)
       private: true
   roles:
-    - role: artis3n.tailscale
+    - role: artis3n.tailscale.machine
       vars:
         tailscale_args: "--ssh --advertise-exit-node --hostname={{ inventory_hostname }}"
+        tailscale_tags:
+          - homelab
+        tailscale_oauth_ephemeral: false
+        tailscale_oauth_preauthorized: true
         state: latest
 ```
 
 - `--ssh` enables Tailscale SSH (admin access goal).
 - `--advertise-exit-node` offers each node as an exit node.
 - `--hostname` makes tailnet device names match inventory hostnames.
-- `tailscale_authkey` is set play-wide by `vars_prompt`; the role consumes it
-  automatically (no explicit var-pass needed).
+- `tailscale_authkey` is set play-wide by `vars_prompt`; the role detects an
+  OAuth client secret (prefix `tskey-client-`) automatically and exchanges it
+  for an ephemeral auth key at `tailscale up` time.
+- `tailscale_tags: [homelab]` → role advertises `--advertise-tags=tag:homelab`.
+  **Required** with OAuth (the role fails fast if an OAuth key is given without
+  tags).
+- `tailscale_oauth_ephemeral: false` — nodes are always-on; they must persist
+  on the tailnet, not auto-deregister when briefly offline.
+- `tailscale_oauth_preauthorized: true` — nodes join without a manual device
+  approval click in the console.
 
 **Prerequisite:** exit-node routing needs IPv4/IPv6 forwarding enabled.
 `cluster-prepare.yml` already sets `net.ipv4.ip_forward=1` and
 `net.ipv6.conf.all.forwarding=1`, so node prep must have run before this
 playbook. (This playbook does not set forwarding itself.)
 
-**Console step:** an advertised exit node must be manually approved/enabled in
-the Tailscale admin console (Machines → node → Edit route settings → Use as
-exit node), and clients select it explicitly. Not automatable without
-OAuth/ACL — out of scope.
+### 3. Credential — OAuth client secret, prompted at runtime (no stored secret)
 
-### 3. Auth key — prompted at runtime (no stored secret)
+Authentication uses a **Tailscale OAuth client** (Settings → OAuth clients),
+not a static auth key. The client secret (`tskey-client-...`) is prompted at
+runtime via `vars_prompt` (`private: true` keeps it off-screen and out of
+logs). No sops file, no secret in git.
 
-The auth key is a long-lived (up to 90d) credential. Rather than persist it in
-the repo, the playbook prompts for it on each run via `vars_prompt`
-(`private: true` keeps it off-screen and out of logs). No sops file, no secret
-in git — smaller blast radius.
+Why OAuth over a static auth key: the OAuth client secret does **not expire**
+(static auth keys cap at 90 days). The role mints a short-lived ephemeral key
+from the client secret per run, so there is no long-lived join token to rotate.
 
-This is operationally cheap: the auth key is only needed at `tailscale up`
-time (node join). Once a node authenticates, it stays on the tailnet via its
-own persistent node key across reboots — so re-entry is only required when
-adding or re-joining a node, not for normal operation.
+This is operationally cheap: the secret is only needed at `tailscale up` time
+(node join). Once a node authenticates, it stays on the tailnet via its own
+persistent node key across reboots — so re-entry is only required when adding
+or re-joining a node, not for normal operation.
 
-Key generated in the Tailscale admin console at apply time. **Non-ephemeral**
-recommended (these are always-on admin nodes that should persist across
-reboots); ephemeral would auto-deregister an offline node.
+**Tailnet prerequisite (one-time, console/ACL):**
+- Define `tag:homelab` in the ACL policy `tagOwners`.
+- Create an OAuth client with the minimal **`auth_keys` (write)** scope for
+  `tag:homelab`. (Not `devices:core` — `auth_keys` is the dedicated
+  key-minting scope and is all the role needs.)
+- (Optional) Add an `autoApprovers.exitNode` entry for `tag:homelab` so the
+  advertised exit nodes are approved automatically — otherwise each node must
+  be enabled as an exit node manually in Machines → Edit route settings.
 
 ### 4. Taskfile target `.taskfiles/ansible.yml`
 
@@ -104,28 +126,30 @@ reboots); ephemeral would auto-deregister an offline node.
 - Routing k3s/etcd traffic over the tailnet.
 - Subnet router (advertising the cluster/pod CIDRs). Exit node only.
 - Setting IP forwarding in this playbook (handled by `cluster-prepare.yml`).
-- Auto-approving exit nodes in the console (manual / requires OAuth+ACL).
-- Storing the auth key in repo (sops or otherwise) — prompted at runtime
-  instead.
-- OAuth client + ACL tag automation (prompted key is sufficient for admin
-  access; can revisit if fleet grows).
+- Managing the tailnet ACL policy / OAuth client / `tagOwners` in this repo —
+  these are one-time console/ACL setup steps, done outside ansible.
+- Storing the OAuth client secret in repo (sops or otherwise) — prompted at
+  runtime instead.
 - Removing/uninstalling anything WireGuard from nodes — nothing was ever
   installed, so only the dead `requirements.yml` entry needs removal.
 
 ## Verification
 
-1. `task ansible:init` — galaxy resolves `artis3n.tailscale` v5.0.1, no
-   wireguard role pulled.
-2. `task ansible:tailscale` — prompts for auth key, role completes,
-   `tailscale status` shows all 3 nodes online on the tailnet with SSH and
-   exit-node advertised (`tailscale status --json` → `ExitNodeOption: true`).
+1. `task ansible:init` — galaxy installs the `artis3n.tailscale` collection
+   v1.2.1, no wireguard role pulled.
+2. `task ansible:tailscale` — prompts for the OAuth client secret, role
+   completes, `tailscale status` shows all 3 nodes online on the tailnet
+   tagged `tag:homelab` with SSH and exit-node advertised (`tailscale status
+   --json` → `ExitNodeOption: true`).
 3. SSH a node via its tailnet IP/hostname succeeds.
-4. After enabling an exit node in the console, a client `tailscale up
-   --exit-node=<node>` routes egress through it.
+4. Exit node routing: once approved (auto via `autoApprovers` or manually), a
+   client `tailscale up --exit-node=<node>` routes egress through it.
 5. k3s unaffected: `kubectl get nodes` still Ready, internal IPs still
    10.10.0.x.
 
 ## Unresolved Questions
 
-- None blocking. Auth key is generated in the console at apply time;
-  non-ephemeral recommended for always-on nodes.
+- None blocking. The OAuth client + `tag:homelab` `tagOwners` are created once
+  in the Tailscale console/ACL before the first apply; exit-node approval is
+  either automatic (`autoApprovers.exitNode` for `tag:homelab`) or a manual
+  per-node console step.

--- a/requirements.yml
+++ b/requirements.yml
@@ -12,10 +12,9 @@ collections:
     version: 6.3.0
   - name: devsec.hardening
     version: 10.5.2
+  - name: artis3n.tailscale
+    version: 1.2.1
 roles:
   - name: xanmanning.k3s
     src: https://github.com/PyratLabs/ansible-role-k3s.git
     version: v3.6.2
-  - name: githubixx.ansible_role_wireguard
-    src: https://github.com/githubixx/ansible-role-wireguard.git
-    version: 19.1.0


### PR DESCRIPTION
## Summary

Replaces the unused `githubixx.ansible_role_wireguard` dependency with the `artis3n.tailscale` collection v1.2.1 (role `.machine`), run on all 3 nodes (`homelab`) for tailnet SSH access + exit-node advertising. Auth via Tailscale OAuth client, nodes tagged `tag:homelab`. k3s networking untouched.

## Changes

- **requirements.yml**: drop unused wireguard role; add `artis3n.tailscale` collection v1.2.1
- **bootstrap/ansible/playbooks/tailscale.yml**: new playbook; OAuth client secret prompted at runtime (`vars_prompt`, `private: true`, never stored); `tailscale_tags: [homelab]`, `oauth_ephemeral: false`, `oauth_preauthorized: true`; `tailscale up --ssh --advertise-exit-node --hostname=<node>`
- **.taskfiles/ansible.yml**: add `ansible:tailscale` target
- spec + plan docs

## Design / context

- **Collection, not standalone role**: the standalone `artis3n.tailscale` v5.0.1 is abandoned and breaks on ansible-core ≥2.19 (a `meta: end_role` task with a string `when:` violates strict boolean conditionals; relies on deprecated `INJECT_FACTS_AS_VARS`). The collection role `artis3n.tailscale.machine` fixes both, same variable interface.
- **OAuth over static auth key**: OAuth client secret does not expire (static auth keys cap at 90d). Role mints an ephemeral key per run.
- **Minimal OAuth scope**: `auth_keys` (write) for `tag:homelab` — not `devices:core`.
- `tag:homelab` required with OAuth (role fails fast otherwise).

## Post-merge manual steps (live apply)

1. One-time tailnet setup (console/ACL): `tag:homelab` in `tagOwners`; optional `autoApprovers.exitNode: [tag:homelab]`; OAuth client scoped `auth_keys` write for `tag:homelab`
2. `mise exec -- task ansible:tailscale` (paste OAuth secret)
3. Verify nodes online + `Tags: ['tag:homelab']`, exit-node advertised
4. Approve exit nodes; confirm `kubectl get nodes` unaffected

> **Known cosmetic issue:** the role wraps `tailscale up` in ansible async, which returns `jid=None` on ansible-core 2.21 — the command succeeds (nodes join) but ansible reports failure. Auth works; re-runs re-auth. Not blocking.

> **Stacked PR:** based on #325 (forwarding) → #324 (init fix). Exit-node routing needs the IPv6 forwarding fix in #325. Merge order: #324 → #325 → this.

Supersedes #323 (which mixed all three concerns on one branch).