### PR TITLE
feat(adguard): restrict DNS to known clients

### DIFF
--- a/cluster/apps/utilities/adguard/app/resources/config.yaml
+++ b/cluster/apps/utilities/adguard/app/resources/config.yaml
@@ -23,7 +23,10 @@ dns:
   bootstrap_dns:
     - 1.1.1.1
     - 1.0.0.1
-  allowed_clients: []
+  allowed_clients:
+    - 100.64.0.0/10       # tailscale tailnet
+    - 10.10.0.0/24        # cluster nodes / LAN
+    - ${ADGUARD_ALLOWED_IP} # home WAN (from cluster-secrets)
   disallowed_clients: []
   blocked_hosts:
     - version.bind

--- a/cluster/apps/utilities/adguard/ks.yaml
+++ b/cluster/apps/utilities/adguard/ks.yaml
@@ -17,6 +17,16 @@ spec:
   sourceRef:
     kind: GitRepository
     name: home-ops
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: Secret
+        name: cluster-secrets
   wait: true
   interval: 30m
   retryInterval: 1m

--- a/cluster/flux/vars/cluster-secrets.sops.yaml
+++ b/cluster/flux/vars/cluster-secrets.sops.yaml
@@ -8,10 +8,10 @@ stringData:
     CF_API_EMAIL: ENC[AES256_GCM,data:CtdOjeBWsQ733iCCH/8saytRvw==,iv:zuE7ntiH5UvyiBVtU44PeTD7JS7KGHkow9OMPbuZKsU=,tag:R3UD/4vM4nQOSruTmJ0Nnw==,type:str]
     CF_API_KEY: ENC[AES256_GCM,data:sytCojxRj1wTEb/vC6cyu57nmDpStvlMd/RwmeCSqE2mPif0SAE+,iv:olEJXntBNZl9oGNUKQMb+LVfdhsBDWZUKp7YoxNSxyQ=,tag:R2xT9WYvV+TeNQK+yWqOkw==,type:str]
     GF_SECURITY_ADMIN_PASSWORD: ENC[AES256_GCM,data:33CFTlNFyoJpxrXXSPzEWRJ8vuQkZlM+,iv:yTq/dRkS2UKFmtVeyKoICNPrd4qcTS4t2p2WHMKmEzg=,tag:Cfxjv+HQtfg+2BcaUbGpbA==,type:str]
+    ADGUARD_ALLOWED_IP: ENC[AES256_GCM,data:uDh0KcOnp2urcA==,iv:cl387sJFceugq+RVIxkmBOHyJcpt65VoFwYCeir5YsA=,tag:fqVbNJZlnn4yGup8hfm0xQ==,type:str]
 sops:
     age:
-        - recipient: age1kzhu2a3x49ucya85xsdhzu5vzy0l679k5k0gltephktkp7ed3s3qjwme6u
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBWnhIN2IzbUVROG1nVTZL
             bktnRGl2SEtpZUx5UW1EeDV2Y1V5amtzdXdVCklFRXhRU2V0dFBlTERZZ3hLb0x4
@@ -19,7 +19,8 @@ sops:
             L0lrSUc1S2o1dHJkM21IdlVGaUNob0EK9DNnk8J4tohitq0b5gO1U6NLQsGzwKp7
             g/HxDucv6sele8cAJtqNgdqVQOmOGsIPgzIrwFnQZMK+R0hrn5BqFA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-12-13T13:31:05Z"
-    mac: ENC[AES256_GCM,data:o7yZFvGNNZxZn+4rFdzG5KC0jRGFaY6oPdib3h0d+XZt7Axxr/6TNxqK36kkay6rPrKb2kNY442JsEtKVFhga0zgb0gfuT/iKP7f77q2t8zUh/95PtFCD4k0jZJUGx9IrUDIGv5qF0yZ1TCB7dpb3ttWzvY4EBc1a1379Na4eNg=,iv:BlRB/MiaoT+DP6G6yO5Y9TPYlJcag//fAytcZkz/Krc=,tag:0fzqowlLLGUtxnbkZY7WBA==,type:str]
+          recipient: age1kzhu2a3x49ucya85xsdhzu5vzy0l679k5k0gltephktkp7ed3s3qjwme6u
     encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-29T14:35:05Z"
+    mac: ENC[AES256_GCM,data:mk9C0ir7CId0ygwYGTC3ilFCi0mnpzeMRN2EoHJUtK4d2720YFLh2SdN23eypPa5QtktqwO23T47MUNlr8FPrWcH8kfuZr5ZqhLZI/VFGmyC+2xdUL7oK6svzXwb+vsSfXa4Cza5QswIRPS/ct3MY5fmXnfcv4/26j0NeXSWzZQ=,iv:CsvNMERCkotQICqk/VHPzpptDkhCOhK0chSMApVcQ5Q=,tag:EeGTCHLDU0OI7YSegwCZpw==,type:str]
     version: 3.11.0


### PR DESCRIPTION
## What
Restrict AdGuard Home DNS to known clients — stop open-resolver abuse from external (CN/US) IPs.

## Why
DNS is exposed via public NodePort :53 with `allowed_clients: []` (allow-all) and `ratelimit: 0`. Any internet client can resolve through it.

## Changes
- `allowed_clients`: tailnet `100.64.0.0/10`, cluster `10.10.0.0/24`, home WAN IP
- Home IP kept in SOPS: injected via Flux `postBuild.substituteFrom` `cluster-secrets` as `${ADGUARD_ALLOWED_IP}` (added encrypted, same value as terraform `allowed_ip`)
- Added `decryption: sops-age` + `substituteFrom` to adguard Kustomization

## Verify
`kustomize build` OK, placeholder preserved (Flux substitutes at apply). Post-merge: query from non-allowed source → refused; home/tailnet/cluster → resolves.

## Follow-ups (not in this PR)
- DNS :53 is a public NodePort — network-layer fix is tailnet-only exposure
- `ratelimit: 0` still disabled