### PR TITLE
fix(terraform): restrict public DNS :53 to allowed IP

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -132,6 +132,8 @@ resource "upcloud_firewall_rules" "nodes" {
     direction              = "in"
     family                 = "IPv4"
     protocol               = "udp"
+    source_address_start   = data.sops_file.secrets.data.allowed_ip
+    source_address_end     = data.sops_file.secrets.data.allowed_ip
   }
 
   firewall_rule {
@@ -142,6 +144,8 @@ resource "upcloud_firewall_rules" "nodes" {
     direction              = "in"
     family                 = "IPv4"
     protocol               = "tcp"
+    source_address_start   = data.sops_file.secrets.data.allowed_ip
+    source_address_end     = data.sops_file.secrets.data.allowed_ip
   }
 
   firewall_rule {


### PR DESCRIPTION
## What
Lock down public DNS (:53) on the cluster nodes to the home IP only.

## Why
The AdGuard DNS firewall rules (UDP+TCP :53) were `accept` from **any** source — an open resolver. External (CN/US) clients could query it freely. This is the real cause of the abuse.

The app-layer `allowed_clients` allowlist (#335) does **not** stop it: the DNS service uses `externalTrafficPolicy: Cluster`, which SNATs the client source IP to an internal address before it reaches AdGuard, so every external query looks like an allowed internal client. Fix must be at the firewall.

## Change
Scope both AdGuard DNS rules (UDP + TCP :53) to `allowed_ip`, matching the existing SSH (:22) and k8s API (:6443) rules.

## Impact
- Home IP (`allowed_ip`) → still resolves ✓
- Tailnet clients → reach AdGuard over WireGuard (`100.x`, port 41641 already allowed), **not** public :53 → unaffected ✓
- LAN clients → private `10.10.0.0/24` → unaffected ✓
- External abusers → dropped at firewall ✓

Complements #335 (allowlist stays as defense-in-depth for tailnet/LAN).

## Verify
`terraform fmt` clean, `terraform validate` ✓. Post-apply: `dig @<node-public-ip> example.com` from a non-home IP → timeout; from home → resolves.